### PR TITLE
Unix ports

### DIFF
--- a/spampd.pl
+++ b/spampd.pl
@@ -1050,10 +1050,13 @@ Options:
   --host=host[:port]       Hostname/IP and optional port to listen on. 
 	                          Default is 127.0.0.1 port 10025
   --port=n                 Port to listen on (alternate syntax to above).
+  --socket=socketpath      UNIX socket to listen on. Alternative to
+                                  --host and --port.
   --relayhost=host[:port]  Host to relay mail to. 
 	                          Default is 127.0.0.1 port 25.
   --relayport=n            Port to relay to (alternate syntax to above).
-  
+  --relaysocket            UNIX socket to relay to. Alternative to
+                                  --relayhost and --relayport.
   --children=n             Number of child processes (servers) to start and
                                keep running. Default is 5 (plus 1 parent proc).
   --maxrequests=n          Maximum requests that each child can process before
@@ -1159,6 +1162,8 @@ SpamPD - Spam Proxy Daemon (version 2.2)
 B<spampd>
 [B<--host=host[:port]>]
 [B<--relayhost=hostname[:port]>]
+[B<--socket>]
+[B<--relaysocket>]
 [B<--user|u=username>]
 [B<--group|g=groupname>]
 [B<--children|c=n>]
@@ -1365,6 +1370,11 @@ public interface (IP address) unless you know exactly what you're doing!
 Specifies what port I<spampd> listens on. By default, it listens on
 port 10025. This is an alternate to using the above --host=ip:port notation.
 
+=item B<--socket=socketpath>
+
+Specifies what UNIX socket I<spampd> listens on. If this is specified,
+--host and --port are ignored.
+
 =item B<--relayhost=ip[:port] or hostname[:port]>
 
 Specifies the hostname/IP where I<spampd> will relay all
@@ -1375,6 +1385,11 @@ defaults to 25.
 
 Specifies what port I<spampd> will relay to. Default is 25. This is an 
 alternate to using the above --relayhost=ip:port notation.
+
+=item B<--relaysocket=socketpath>
+
+Spevifies what UNIX socket spampd will relay to. If this is specified
+--relayhost and --relayport will be ignored.
 
 =item B<--user=username> or B<--u=username>
 

--- a/spampd.pl
+++ b/spampd.pl
@@ -1052,6 +1052,8 @@ Options:
   --port=n                 Port to listen on (alternate syntax to above).
   --socket=socketpath      UNIX socket to listen on. Alternative to
                                   --host and --port.
+  --socket-perms=perms     The file mode to set on the created UNIX
+                                  socket in octal format.
   --relayhost=host[:port]  Host to relay mail to. 
 	                          Default is 127.0.0.1 port 25.
   --relayport=n            Port to relay to (alternate syntax to above).
@@ -1163,6 +1165,7 @@ B<spampd>
 [B<--host=host[:port]>]
 [B<--relayhost=hostname[:port]>]
 [B<--socket>]
+[B<--socket-perms>]
 [B<--relaysocket>]
 [B<--user|u=username>]
 [B<--group|g=groupname>]
@@ -1374,6 +1377,11 @@ port 10025. This is an alternate to using the above --host=ip:port notation.
 
 Specifies what UNIX socket I<spampd> listens on. If this is specified,
 --host and --port are ignored.
+
+=item B<--socket-perms=mode>
+
+The file mode fo the created UNIX socket (see --socket) in octal
+format, e.g. 700 to specify acces only for the user spampd is run as.
 
 =item B<--relayhost=ip[:port] or hostname[:port]>
 
@@ -1591,6 +1599,20 @@ on another host.
 and the SA auto-whitelist feature
 
   spampd --port=10025 --relayhost=127.0.0.1:10026 --auto-whitelist
+
+=item Using UNIX sockets instead if INET ports
+
+Spampd listens on the UNIX socket /var/run/spampd.socket with
+persmissions 700 instead of a TCP port:
+
+spampd --socket /var/run/spampd.socket --socket-perms 700
+
+Spampd will relay mail to /var/run/dovecot/lmtp instead of a TCP port:
+
+spampd --relaysocket /var/run/dovecot/lmtp
+
+Remember that the user spampd runs as needs to have read AND write
+permissions on the relaysocket!
 
 =back
 


### PR DESCRIPTION
Let's try this once again.

These changes enable the possibility to listen on and relay to UNIX sockets instead of INET. This is controlled via the `--socket` and `--relaysocket` options. When they are specified their corresponding `--(relay-)host` and `--(relay-)port` counterparts are ignored.

It is also possible to specify different permissions for the listening socket via the `--socket-perms` option. Originally I intended to add options for controlling the owning user and group of the created socket, but`Net::Server` doesn't seem to support this and does a good job at preventing this from being done in a hook.

Note: The unix-ports branch doesn't contain the commits from my previous merge request, so you may need to pull with `--force`.