### PR TITLE
Add X-Envelope-* headers before Received so they are not ignored by SpamAssassin

### DIFF
--- a/spampd.pl
+++ b/spampd.pl
@@ -480,12 +480,12 @@ sub process_message {
     	    	if ( ( $self->{spampd}->{envelopeheaders} || 
 	    				$self->{spampd}->{setenvelopefrom} ) && 
 	    				$envfrom == 0 ) {
-		    		push(@msglines, "X-Envelope-From: $sender\r\n");
+		    		unshift(@msglines, "X-Envelope-From: $sender\r\n");
 					if ( $self->{spampd}->{debug} ) {
 					  $self->mylog(2, "Added X-Envelope-From"); }
 	    		}
     	    	if ( $self->{spampd}->{envelopeheaders} && $envto == 0 ) {
-	       	 		push(@msglines, "X-Envelope-To: $recips\r\n");
+	       	 		unshift(@msglines, "X-Envelope-To: $recips\r\n");
 	        		$addedenvto = 1;
 					if ( $self->{spampd}->{debug} ) {
 					  $self->mylog(2, "Added X-Envelope-To"); }


### PR DESCRIPTION
When `X-Envelope-From` is added after `Received`, it is ignored by SpamAssassin, which logs the following message:

    message: X-Envelope-From header found after 1 or more Received lines, cannot trust envelope-from

For reference, see [/lib/Mail/SpamAssassin/PerMsgStatus.pm:2859](https://github.com/apache/spamassassin/blob/spamassassin_release_3_4_1/lib/Mail/SpamAssassin/PerMsgStatus.pm#L2859).

To avoid this, add the headers to the beginning of the message.

Thanks for considering,
Kevin