### PR TITLE
Put X-Envelope-* headers to the beginning, so SA actually uses them

### DIFF
--- a/spampd.pl
+++ b/spampd.pl
@@ -961,7 +961,7 @@ if ( $saconfigfile != "" ) {
 }
 
 #cleanup environment before starting SA (thanks to Alexander Wirt)
-$ENV{'PATH'} = '/bin:/usr/bin:/sbin:/usr/sbin';
+$ENV{'PATH'} = '/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin';
 delete @ENV{'IFS', 'CDPATH', 'ENV', 'BASH_ENV', 'HOME'};
 
 my $assassin = Mail::SpamAssassin->new($sa_options);

--- a/spampd.pl
+++ b/spampd.pl
@@ -480,12 +480,12 @@ sub process_message {
     	    	if ( ( $self->{spampd}->{envelopeheaders} || 
 	    				$self->{spampd}->{setenvelopefrom} ) && 
 	    				$envfrom == 0 ) {
-		    		push(@msglines, "X-Envelope-From: $sender\r\n");
+		    		unshift(@msglines, "X-Envelope-From: $sender\r\n");
 					if ( $self->{spampd}->{debug} ) {
 					  $self->mylog(2, "Added X-Envelope-From"); }
 	    		}
     	    	if ( $self->{spampd}->{envelopeheaders} && $envto == 0 ) {
-	       	 		push(@msglines, "X-Envelope-To: $recips\r\n");
+	       	 		unshift(@msglines, "X-Envelope-To: $recips\r\n");
 	        		$addedenvto = 1;
 					if ( $self->{spampd}->{debug} ) {
 					  $self->mylog(2, "Added X-Envelope-To"); }


### PR DESCRIPTION
This helps checks like SPF to function properly.

Also, add /usr/local/bin and /usr/local/sbin to PATH before starting SA, as this will allow pyzor and razor etc. work on unices that install 3rd party software there.