### PR TITLE
- Fix listening to IP address (8cdc4c6 broke this, leading to error [0])...

### DIFF
--- a/spampd.pl
+++ b/spampd.pl
@@ -415,6 +415,7 @@ sub yammer {
 package SpamPD;
 
 use strict;
+use File::HomeDir;
 use Net::Server::PreForkSimple;
 use IO::File;
 use Getopt::Long;
@@ -949,7 +950,7 @@ my $sa_options = {
 		'debug' => $debug,
 		'local_tests_only' => $options{'local-only'} || 0,
 		'home_dir_for_helpers' => $sa_home_dir, 
-		'user_dir' => (getpwnam($user))[7],
+		'user_dir' => File::HomeDir->users_home($user),
 		'userstate_dir' => $sa_home_dir, 
 		'username' => $user
 };
@@ -1223,6 +1224,8 @@ Perl modules:
 =item B<Mail::SpamAssassin>
 
 =item B<Net::Server::PreForkSimple>
+
+=item B<File::HomeDir>
 
 =item B<IO::File>
 

--- a/spampd.pl
+++ b/spampd.pl
@@ -3,6 +3,8 @@
 ######################
 # SpamPD - spam proxy daemon
 #
+# v2.51  - 01-May-18
+# v2.50  - 30-Apr-18
 # v2.42  - 08-Dec-13
 # v2.41  - 11-Aug-10
 # v2.40  - 10-Jan-09
@@ -415,7 +417,6 @@ sub yammer {
 package SpamPD;
 
 use strict;
-use File::HomeDir;
 use Net::Server::PreForkSimple;
 use IO::File;
 use Getopt::Long;
@@ -953,7 +954,6 @@ my $sa_options = {
 		'debug' => $debug,
 		'local_tests_only' => $options{'local-only'} || 0,
 		'home_dir_for_helpers' => $sa_home_dir, 
-		'user_dir' => File::HomeDir->users_home($user),
 		'userstate_dir' => $sa_home_dir, 
 		'username' => $user
 };
@@ -1232,8 +1232,6 @@ Perl modules:
 =item B<Mail::SpamAssassin>
 
 =item B<Net::Server::PreForkSimple>
-
-=item B<File::HomeDir>
 
 =item B<IO::File>
 

--- a/spampd.pl
+++ b/spampd.pl
@@ -827,6 +827,7 @@ my $nsloglevel = 2; # default log level for Net::Server (in the range 0-4)
 my $background = 1; # specifies whether to 'daemonize' and fork into background;
 					# apparently useful under Win32/cygwin to disable this via 
 					# --nodetach option;
+my $setsid = 0; # specifies wheter to use POSIX::setsid() command to truly daemonize.
 my $envelopeheaders = 0; # Set X-Envelope-To and X-Envelope-From headers in the mail before
 						 # passing it to spamassassin. Set to 1 to enable this.
 my $setenvelopefrom = 0; # Set X-Envelope-From header only
@@ -888,6 +889,7 @@ usage(1) unless GetOptions(\%options,
 		   'hostname=s',  # deprecated
 		   'logsock=s',
 		   'nodetach',
+		   'setsid',
 		   'set-envelope-headers|seh',
 		   'set-envelope-from|sef',
 		   'saconfig=s',
@@ -926,6 +928,7 @@ if ( $options{'log-rules-hit'} ) { $rh = 1; }
 if ( $options{debug} ) { $debug = 1; $nsloglevel = 4; }
 if ( $options{dose} ) { $dose = 1; }
 if ( $options{'nodetach'} ) { $background = undef; }
+if ( $options{'setsid'} && defined($background)) { $setsid = 1; }
 if ( $options{'set-envelope-headers'} ) { $envelopeheaders = 1; }
 if ( $options{'set-envelope-from'} ) { $setenvelopefrom = 1; }
 if ( $options{'saconfig'} ) { $saconfigfile = $options{'saconfig'}; }
@@ -1008,7 +1011,7 @@ my $server = bless {
 				syslog_ident => 'spampd',
 				syslog_facility => 'mail',
 				background => $background,
-				setsid => $background,
+				setsid => $setsid,
 				pid_file => $pidfile,
 				user => $user,
 				group => $group,
@@ -1082,6 +1085,10 @@ Options:
                                background. Useful for some daemon control
                                tools or when running as a win32 service
                                under cygwin.
+  --setsid                 Fork after the bind method to release itself
+                               from the command line and then run the
+                               POSIX::setsid() command to truly daemonize.
+                               Only used if --nodetach isn't specified.
                                
   --logsock=inet or unix   Allows specifying the syslog socket type. Default is 
                                'unix' except on HPUX and SunOS which prefer 'inet'.
@@ -1178,6 +1185,7 @@ B<spampd>
 [B<--satimeout=n>]
 [B<--pid|p=filename>]
 [B<--nodetach>]
+[B<--setsid>]
 [B<--logsock=inet|unix>]
 [B<--maxsize=n>]
 [B<--dose>]
@@ -1472,6 +1480,12 @@ If this option is given spampd won't detach from the console and fork into the
 background. This can be useful for running under control of some daemon
 management tools or when configured as a win32 service under cygrunsrv's
 control.
+
+=item B<--setsid> C<(new in v2.51)>
+
+If this option is given spampd will fork after the bind method to release
+itself from the command line and then run the POSIX::setsid() command to truly
+daemonize. Only used if --nodetach isn't specified.
 
 =item B<--maxsize=n>
 

--- a/spampd.pl
+++ b/spampd.pl
@@ -433,7 +433,7 @@ BEGIN {
 
 use vars qw(@ISA $VERSION);
 our @ISA = qw(Net::Server::PreForkSimple);
-our $VERSION = '2.42';
+our $VERSION = '2.51';
 
 sub process_message {
 	my ($self, $fh) = @_;
@@ -909,15 +909,15 @@ $relayhost = $1 if $relayhost =~ /^(.*)$/;
 
 $relayport = $1 if $relayport =~ /^(.*)$/;
 
-$relaysocket = $1 if $relaysocket =~ /^(.*)$/;
+$relaysocket = $1 if defined($relaysocket) && $relaysocket =~ /^(.*)$/;
 
 $host = $1 if $host =~ /^(.*)$/;
 
 $port = $1 if $port =~ /^(.*)$/;
 
-$socket = $1 if $socket =~ /^(.*)$/;
+$socket = $1 if defined($socket) && $socket =~ /^(.*)$/;
 
-$socket_perms = $1 if $socket_perms =~ /^(.*)$/;
+$socket_perms = $1 if defined($socket_perms) && $socket_perms =~ /^(.*)$/;
 #
 
 if ( $options{tagall} ) { $tagall = 1; }
@@ -949,6 +949,7 @@ my $sa_options = {
 		'debug' => $debug,
 		'local_tests_only' => $options{'local-only'} || 0,
 		'home_dir_for_helpers' => $sa_home_dir, 
+		'user_dir' => (getpwnam($user))[7],
 		'userstate_dir' => $sa_home_dir, 
 		'username' => $user
 };
@@ -1006,7 +1007,7 @@ my $server = bless {
 				syslog_ident => 'spampd',
 				syslog_facility => 'mail',
 				background => $background,
-				# setsid => 1,
+				setsid => $background,
 				pid_file => $pidfile,
 				user => $user,
 				group => $group,


### PR DESCRIPTION
 ...by making sure $(relay)socket is only defined if passed.
- Bump version to upcoming release 2.51 (wasn't bumbed on 2.50)
- Set user_dir for SA to home dir of user running spampd
  (taken from FreeBSD port)
- Use setsid if running in background (--nodetach isn't set). This
  has been commented out for quite a while (if this is not wanted,
  could also be changed to being optional)

[0]
Could not determine port number from host [*]:unix    at line 78 in
file /usr/local/lib/perl5/site_perl/Net/Server/Proto.pm