### PR TITLE
Add child stats for process name, SA RULESVERSION for logging, and some optimizations.

### DIFF
--- a/spampd.pl
+++ b/spampd.pl
@@ -571,7 +571,7 @@ sub init {
     perl_ver      => sprintf("%vd", $^V), # (split(/v/, $^V))[-1];
     ns_ver        => Net::Server->VERSION(),
     ns_typ        => $ns_type,
-    ns_typ_acr    => $ns_type=~s/[a-z]//rg,
+    ns_typ_acr    => do { (my $tmp = $ns_type) =~ s/[a-z]//g; $tmp },
     sa_ver        => Mail::SpamAssassin::Version(),
     sa_rls_ver    => $sa_rules_ver || "(unknown)",
     child_count   => 0,   # total # of children launched
@@ -1475,7 +1475,7 @@ sub sprintf_named {
   )}xs;
 
   my @args;
-  my sub replace {
+  my $replace = sub {
     my ($all, $fmt, $npi, $flags, $vflag, $width, $dot, $prec, $conv) = @_;
     if ($fmt && defined($npi) && defined(my $val = $hash->{$npi})) {
       push(@args, $val);
@@ -1484,8 +1484,8 @@ sub sprintf_named {
       );
     }
     return $all;
-  }
-  $format =~ s/$regex/replace($1, $2, $3, $4, $5, $6, $7, $8, $9)/ge;
+  };
+  $format =~ s/$regex/$replace->($1, $2, $3, $4, $5, $6, $7, $8, $9)/ge;
   # use Data::Dump; dd [$format, @args];
   return sprintf($format, @args);
 }

--- a/spampd.pl
+++ b/spampd.pl
@@ -1180,7 +1180,8 @@ sub child_init_hook {
   # set process name to help clarify via process listing which is child/parent
   my $me = $0;
   eval { $me = $1 if ($me =~ m/^.*?([\w-]+)(?:\.[\w-]+)*$/); };
-  $0 = $me.' child';
+  $me .= ': child v' . $_[0]->runtime_version();
+  eval { $0 = $me; };
 }
 
 # Net::Server hook: about to exit child process

--- a/spampd.pl
+++ b/spampd.pl
@@ -979,6 +979,8 @@ sub process_message {
 
       # use Mail::SpamAssassin:PerMsgStatus object to rewrite message
       if ($prop->{sa_version} >= 3) {
+        # inject _SPAMPDVERSION_ as a "template tag" (macro) for SA add_header
+        $status->set_tag("SPAMPDVERSION", $self->VERSION) if ($prop->{sa_version} >= 3.0020);
         $msg_resp = $status->rewrite_mail;
       }
       else {
@@ -1758,6 +1760,12 @@ especially beefy or weak server box because I<spampd> is a memory-hungry
 program.  Check the L<"Options"> for details on this and all other parameters.
 
 To show default values for all options, run C<spampd --show defaults>.
+
+B<Since v2.61> I<spampd> injects a C<_SPAMPDVERSION_>
+L<"template tag"|https://spamassassin.apache.org/doc/Mail_SpamAssassin_Conf.html#TEMPLATE-TAGS>
+macro at message processing time. This can be used in an C<add_header> SA config file directive, for example.
+
+  add_header all Filter-Version SpamAssassin _VERSION_ (_SUBVERSION_, Rules: _RULESVERSION_) / SpamPD _SPAMPDVERSION_
 
 Note that B< I<spampd> replaces I<spamd> > from the I<SpamAssassin> distribution
 in function. You do not need to run I<spamd> in order for I<spampd> to work.

--- a/spampd.pl
+++ b/spampd.pl
@@ -1135,10 +1135,13 @@ sub process_request {
       # patch for LMTP - multiple responses after . after DATA, done by Vladislav Kurz
       # we have to count sucessful RCPT commands and then read the same amount of responses
       if ($smtp_server->{proto} eq 'lmtp') {
-        if ($smtp_server->{state} =~ /^rset/i) { $rcpt_ok = 0; }
-        if ($smtp_server->{state} =~ /^mail/i) { $rcpt_ok = 0; }
-        if ($smtp_server->{state} =~ /^rcpt/i and $destresp =~ /^25/) { $rcpt_ok++; }
-        if ($smtp_server->{state} eq '.') {
+        if ($smtp_server->{state} =~ /^(?:rset|mail)/i) {
+          $rcpt_ok = 0;
+        }
+        elsif ($smtp_server->{state} =~ /^rcpt/i and $destresp =~ /^25/) {
+          $rcpt_ok++;
+        }
+        elsif ($smtp_server->{state} eq '.') {
           while (--$rcpt_ok) {
             $destresp = $client->hear;
             $smtp_server->reply($destresp);

--- a/spampd.pl
+++ b/spampd.pl
@@ -558,7 +558,7 @@ sub init {
   # Get the SA "rules update version" for logging and child process name (since v3.4.0).
   # https://github.com/apache/spamassassin/blob/3.4/build/announcements/3.4.0.txt#L334
   # https://github.com/apache/spamassassin/blob/3.4/lib/Mail/SpamAssassin/PerMsgStatus.pm#L1597
-  my $sa_rules_ver = "(unknown)";
+  my $sa_rules_ver;
   ($spd_p->{sa_version} >= 3.0040) and eval {
     $sa_rules_ver = Mail::SpamAssassin::PerMsgStatus->new($sa_p)->get_tag("RULESVERSION");
   };
@@ -573,7 +573,7 @@ sub init {
     ns_typ        => $ns_type,
     ns_typ_acr    => $ns_type=~s/[a-z]//rg,
     sa_ver        => Mail::SpamAssassin::Version(),
-    sa_rls_ver    => $sa_rules_ver,
+    sa_rls_ver    => $sa_rules_ver || "(unknown)",
     child_count   => 0,   # total # of children launched
     child_status  => "D", # (C)onnected, or (D)isconnected
     req_count     => 0,   # num of requests child has processed so far

--- a/spampd.pl
+++ b/spampd.pl
@@ -461,7 +461,7 @@ sub new {
       # default child name template
       child_name_templ  => '%base_name: child #%child_count(%child_status) ' .
                            '[req %req_count/%req_max, time lst/avg/ttl %(req_time_last).3f/%(req_time_avg).3f/%(req_time_ttl).3f, ham/spm %req_ham/%req_spam] ' .
-                           '[SA rules v%sa_rls_ver)]',
+                           '[SA %sa_ver/%sa_rls_ver]',
     },
     # this hash is eventually passed to SpamAssassin->new() so it must use valid SA option names. This also becomes the SA object afterwards.
     assassin => {
@@ -1734,7 +1734,7 @@ Options:
   --set-envelope-from        Set X-Envelope-From header only.
 
   --local-only or -L         Turn off all SA network-based tests.
-  --homedir path             Use the specified directory as SA home.
+  --homedir <path>           Use the specified directory as SA home.
   --saconfig <filename>      Use the file for SA "user_prefs" configuration.
 
   --logfile or -o <dest>     Destination for logs (syslog|stderr|<filename>).
@@ -1975,8 +1975,8 @@ Also note that v2.60 added the ability to use a L</"CONFIGURATION FILE"> for spe
     [--max-servers | -mxs  <n>] [--maxsize   <n>   ] [--[no]detach         ]
     [--maxrequests | -r    <n>] [--local-only | -L ] [--[no]setsid         ]
     [--childtimeout        <n>] [--tagall     | -a ] [--log-rules-hit | -rh]
+    [ --child-name-template | -cnt [<template>] ]    [--homedir <path>     ]
     [ [--set-envelope-headers | -seh] | [--set-envelope-from | -sef] ]
-    [ --child-name-template | -cnt [<string>] ]
 
     [ --logfile | -o (syslog|stderr|<filename>) ][...]
     [ --logsock | -ls <socketpath>    ]  [ --logident    | -li <name> ]
@@ -2695,15 +2695,18 @@ permissions on the relaysocket!
 =head1 CREDITS
 
 I<spampd> is written and maintained by Maxim Paperno <MPaperno@WorldDesign.com>.
-See L<http://www.WorldDesign.com/index.cfm/rd/mta/spampd.htm> for latest info.
+The open source code repository is located at L<https://github.com/mpaperno/spampd/>.
+See L<http://www.WorldDesign.com/index.cfm/rd/mta/spampd.htm> for historical info.
 
-I<spampd> v2 uses two Perl modules by Bennett Todd and Copyright (C) 2001 Morgan
-Stanley Dean Witter. These are distributed under the GNU GPL (see
-module code for more details). Both modules have been slightly modified
-from the originals and are included in this file under new names.
+I<spampd> v2 uses two Perl modules (I<MSDW::SMTP::Client> and I<MSDW::SMTP::Server>)
+by Bennett Todd and Copyright (C) 2001 Morgan Stanley Dean Witter.
+These are distributed under the GNU GPL (see module code for more details).
+Both modules have been slightly modified from the originals and are included in
+this file under new names (I<SpamPD::Client> and I<SpamPD::Server>, respectively).
 
-Also thanks to Bennett Todd for the example smtpproxy script which helped create
-this version of I<spampd>.  See http://bent.latency.net/smtpprox/ .
+Also thanks to Bennett Todd for the example I<smtpproxy> script which helped create
+this version of I<spampd>.  See L<http://bent.latency.net/smtpprox/> (seems to be down)
+or L<https://github.com/jnorell/smtpprox>.
 
 I<spampd> v1 was based on code by Dave Carrigan named I<assassind>. Trace
 amounts of his code or documentation may still remain. Thanks to him for the
@@ -2728,8 +2731,7 @@ See also: L<https://github.com/mpaperno/spampd/graphs/contributors/>
 
 =head1 COPYRIGHT, LICENSE, AND DISCLAIMER
 
-I<spampd> is Copyright (c) 2002-2006, 2009-2010, 2013, 2018-2019 Maxim Paperno;
-All Rights Reserved.
+I<spampd> is Copyright (c) Maxim Paperno;  All Rights Reserved.
 
 Portions are Copyright (c) 2001 Morgan Stanley Dean Witter as mentioned above
 in the Credits section.
@@ -2818,7 +2820,7 @@ L<Integrating SpamAssassin into Postfix using spampd|https://wiki.apache.org/spa
         return word.replace(word[0], word[0].toUpperCase());
       }).join(' ');
     };
-    var list = document.querySelectorAll("a[href*=podtop] h1, ul#index > li > a, h1 a.u, li.indexItem1 > a");
+    var list = document.querySelectorAll("a[href*=podtop] h1, ul#index > li > a, h1 a.u, body > h1[id], li.indexItem1 > a");
     for (let item of list)
       item.innerText = titleCase(item.innerText);
   }


### PR DESCRIPTION
* Add detection and logging of "RULESVERSION" tag with SA >= v3.4.0. (#32)
*  Add tracking of some per-child runtime statistics.
*  Add ability to provide a custom child process name template string (or not modify the child name at all). Template format documented in POD. (#32)
* Optimize initial header processing when building message line array in process_message().
* Slight optimization to LMTP multi-recipient handling in process_request().
* Optimize how rewritten (tagged) message is saved back to temp file: just write all the contents at once instead of line array loop; Any added X-Envelope-To header is removed with regex.
* Add (inject) `_SPAMPDVERSION_` as a "template tag" (macro) before rewriting the message with SA (eg. for use in `add_header` directives). (https://github.com/mpaperno/spampd/issues/32#issuecomment-890486418 again :-)

Closes #32 