### PR TITLE
Replace /etc/default/spampd with /etc/spampd.cfg in README.Debian

### DIFF
--- a/debian/README.Debian
+++ b/debian/README.Debian
@@ -1,7 +1,7 @@
 SpamPD for Debian
 -----------------
 
-SpamPD configuration takes place in /etc/default/spampd as far as the network
+SpamPD configuration takes place in /etc/spampd.cfg as far as the network
 connections are concerned. Any more advanced configuration of the
 SpamAssassin part is done in /etc/spamassassin/local.cf as usual with
 SpamAssassin. Additionally, as of Debian package 2.30-5, it is now possible
@@ -31,8 +31,8 @@ a problem in any case. The second one however can pose a problem for
 really slow clients (or extremely large mails).
 If you experience such problems (i.e. a client isn't able to send
 large mails even though it slowly but steadily sends data), try
-passing "--childtimeout=3600" (60 minutes) to spampd using the
-ADDOPTS entry in /etc/default/spampd.
+passing "--childtimeout=3600" (60 minutes) to spampd by adding
+"childtimeout=3600" to /etc/spampd.cfg.
 
 SpamPD and SpamAssassin's Auto-Whitelist Feature
 ------------------------------------------------

--- a/debian/README.Debian
+++ b/debian/README.Debian
@@ -24,7 +24,7 @@ secure. These notes of caution don't necessarily apply when running SpamPD as
 a pre-queue filter though. Anyway, here is as much help as I can give you with
 either setup. It's mostly related to network timeouts.
 
-By default, SpamPD times out after 5 minutes if no network paket is
+By default, SpamPD times out after 5 minutes if no network packet is
 received or after 6 minutes have gone by since start of the SMTP
 dialogue. The first parameter isn't directly adjustable, but that shouldn't be
 a problem in any case. The second one however can pose a problem for


### PR DESCRIPTION
My understanding is that support for `/etc/default/spampd` was removed in 2.60 and was superseded by `/etc/spampd.cfg`.  This PR updates `debian/README.Debian` accordingly.

Thanks for considering,
Kevin