### PR TITLE
setting local-only to 0 does not enable network tests

### DIFF
--- a/misc/spampd.cfg
+++ b/misc/spampd.cfg
@@ -36,7 +36,8 @@ max-servers       3
 # Whether or not to tag all messages, even non-spam (0/1)
 tagall            1
 
-# Whether or not to do only local checks (disables any network checks like DNS blacklisting) (0/1)
+# Whether or not to do only local checks (disables any network checks like DNS blacklisting)
+# (1 to only run local tests, or comment out to run network tests).
 local-only        1
 
 # Logging destination, could be syslog (default), stderr, or a filename.


### PR DESCRIPTION
It would probably be best to fix this in the code so `local-only 1` works but in the meantime this will help.